### PR TITLE
Fix audio being cut off in mic.html worker example

### DIFF
--- a/worker-example/mic.js
+++ b/worker-example/mic.js
@@ -27,7 +27,8 @@
     function beginRecording(stream) {
       // Set up Web Audio API to process data from the media stream (microphone).
       microphone = context.createMediaStreamSource(stream);
-      processor = context.createScriptProcessor(16384, 1, 1);
+      // Settings a bufferSize of 0 instructs the browser to choose the best bufferSize
+      processor = context.createScriptProcessor(0, 1, 1);
       // Add all buffers from LAME into an array.
       processor.onaudioprocess = function (event) {
         // Send microphone data to LAME for MP3 encoding while recording.


### PR DESCRIPTION
The MDN docs on createScriptProcessor recommends developers allow the browser to choose
the best bufferSize.  It seems large buffer sizes reduce the load
but also reduce quality.  Prior to this commit the maximum possible buffer size was chosen
and that seemed to result in the last part of the audio being clipped off in the recording.

Also worth noting is that apparently the ScriptProcessorNode was deprecated in 2014
but the replacement, Audio Workers, has yet to be implemented in any browsers.

closes #36 I created