### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ way to do this is to:
 1. Link to LAME as separate jar (lame.min.js or lame.all.js)
 
 2. Fully acknowledge that you are using LAME, and give a link
-   to our web site, www.mp3dev.org
+   to our web site, lame.sourceforge.net
 
 3. If you make modifications to LAME, you *must* release these
    these modifications back to the LAME project, under the LGPL.


### PR DESCRIPTION
I went to http://www.mp3dev.org/ and it said:

"The LAME Open Source MP3 Encoder Project has moved to sourceforge."

And the link went to http://lame.sourceforge.net/