### PR TITLE
Document usage with Float32Array / AudioBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,15 @@ if (mp3buf.length > 0) {
 console.log(mp3Data);
 </script>
 ```
+
+# Usage with Float32Array / AudioBuffer
+
+Some libraries (such as `AudioBuffer.getChannelData()` from the WebAudio API) provide audio data as a `Float32Array` with values between `-1.0` and `1.0`. lamejs expects values between `-32768` and `32767`, so the values have to be mapped:
+
+```javascript
+var floatSamples = new Float32Array(44100); // Float sample from an external source
+var samples = new Int32Array(floatSamples.length);
+for (var i = 0; i < floatSamples.length; i++) {
+  samples[i] = floatSamples[i] < 0 ? floatSamples[i] * 32768 : floatSamples[i] * 32767;
+}
+```


### PR DESCRIPTION
It seems that many people are running into problems when trying to use lamejs with a Float32Array. This kind of array is created by the WebAudio API, and I believe libmp3lame-js was also expecting that format.

The README does not really indicate what data format lamejs expects. That’s why I have added a section that explains what format is expected and how to convert a Float32Array to it. In the example I have used an Int32Array because using an Int16Array (like in the other examples) resulted in serious clipping for me.

As a further step, I think it would be nice if lamejs could deal with a Float32Array out of the box, which would save time and resources by making the mapping unnecessary.