### PR TITLE
fix: fix bug in worker example, so that the last second of audio would be fully encoded

### DIFF
--- a/worker-example/worker.js
+++ b/worker-example/worker.js
@@ -41,15 +41,16 @@
     mp3Encoder = new lamejs.Mp3Encoder(wav.channels, wav.sampleRate, config.bitRate || 96);
 
     var remaining = samplesLeft.length;
-    for (var i = 0; remaining >= maxSamples; i += maxSamples) {
-      var left = samplesLeft.subarray(i, i + maxSamples);
+    for (var i = 0; remaining > 0; i += maxSamples) {
+      const chunkSize = Math.min(maxSamples, remaining);
+      var left = samplesLeft.subarray(i, i + chunkSize);
       var right;
       if (samplesRight) {
-        right = samplesRight.subarray(i, i + maxSamples);
+        right = samplesRight.subarray(i, chunkSize);
       }
       var mp3buf = mp3Encoder.encodeBuffer(left, right);
       appendToBuffer(mp3buf);
-      remaining -= maxSamples;
+      remaining -= chunkSize;
       self.postMessage({
         cmd: 'progress',
         progress: (1 - remaining / samplesLeft.length)


### PR DESCRIPTION
Last second (or less) of audio were not encoded into mp3.

When the "remaining" becomes less than the "maxSamples" constant, we exit the loop for encoding audio portions. However, "remaining" may be non-zero, so part of the audio at the end will remain not encoded.